### PR TITLE
[codex] Add appserver diagnostics and request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ pwsh -File .\scripts\doctor.ps1
 pwsh -File .\scripts\start.ps1
 ```
 
+To start a dedicated websocket core explicitly:
+
+```powershell
+python -m imcodex core start --port 8765
+```
+
+Then run the bridge against it:
+
+```powershell
+$env:IMCODEX_CORE_MODE = "dedicated-ws"
+$env:IMCODEX_CORE_URL = "ws://127.0.0.1:8765"
+python -m imcodex
+```
+
 ## Native-First State
 
 `imcodex` now treats native Codex source code and native protocol behavior as
@@ -116,6 +130,34 @@ The adapter currently supports:
 - `GROUP_AT_MESSAGE_CREATE` for group `@bot` chat
 
 QQ inbound messages are mapped to internal conversation ids like `c2c:<openid>` and `group:<group_openid>`, so Codex thread routing and async completion messages can flow back through the QQ API.
+
+## Telemetry
+
+`imcodex` writes runtime telemetry under `.imcodex-run/current/`:
+
+- `bridge.log`
+- `events.jsonl`
+- `health.json`
+
+For app-server troubleshooting, `events.jsonl` now includes structured protocol events for:
+
+- app-server messages sent by the bridge
+- app-server messages received from Codex
+- server requests such as approvals
+- reasoning deltas
+- tool and item lifecycle messages when they reach the bridge
+
+Dedicated websocket cores started with `python -m imcodex core start` also write:
+
+- `.imcodex-core/core.stdout.log`
+- `.imcodex-core/core.stderr.log`
+- `.imcodex-core/core.json`
+
+This makes it possible to compare:
+
+- what the core itself emitted
+- what `imcodex` actually received
+- what the bridge projected or rejected
 
 ## Inbound Webhook
 

--- a/src/imcodex/appserver/__init__.py
+++ b/src/imcodex/appserver/__init__.py
@@ -1,6 +1,6 @@
 from .backend import CodexBackend, StaleThreadBindingError, ThreadSelectionError, TurnSubmission
 from .client import AppServerClient, AppServerError
-from .protocol_map import AppServerEvent, normalize_appserver_message
+from .protocol_map import AppServerEvent, normalize_appserver_message, summarize_transport_message
 from .supervisor import AppServerSupervisor
 
 __all__ = [
@@ -13,4 +13,5 @@ __all__ = [
     "ThreadSelectionError",
     "TurnSubmission",
     "normalize_appserver_message",
+    "summarize_transport_message",
 ]

--- a/src/imcodex/appserver/backend.py
+++ b/src/imcodex/appserver/backend.py
@@ -342,6 +342,21 @@ class CodexBackend:
         )
         self.store.remove_pending_request(request_id)
 
+    async def reply_error_to_transport_request(
+        self,
+        transport_request_id: str | int,
+        *,
+        code: int,
+        message: str,
+        data: object | None = None,
+    ) -> None:
+        await self.client.reply_error_to_transport_request(
+            transport_request_id,
+            code=code,
+            message=message,
+            data=data,
+        )
+
     def _remember_snapshot(self, payload: dict) -> NativeThreadSnapshot:
         status = payload.get("status")
         if isinstance(status, dict):

--- a/src/imcodex/appserver/client.py
+++ b/src/imcodex/appserver/client.py
@@ -7,6 +7,7 @@ import json
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
+from .protocol_map import summarize_transport_message
 from ..observability.runtime import emit_event, mark_appserver_health
 
 
@@ -143,6 +144,7 @@ class AppServerClient:
         self._listener_task: asyncio.Task[None] | None = None
         self._dispatcher_task: asyncio.Task[None] | None = None
         self._dispatch_queue: asyncio.Queue[JsonDict] | None = None
+        self._stderr_task: asyncio.Task[None] | None = None
         self._next_request_id = 1
         self._pending_futures: dict[int, asyncio.Future[JsonDict]] = {}
         self._notification_handlers: list[NotificationHandler] = []
@@ -328,6 +330,7 @@ class AppServerClient:
                 self._transport = StdioAppServerTransport(process)
                 self.connection_mode = "spawned-stdio"
                 self.connection_epoch += 1
+                self._stderr_task = asyncio.create_task(self._drain_process_stderr(process))
                 emit_event(
                     component="appserver.client",
                     event="appserver.connect.spawn_stdio_succeeded",
@@ -374,6 +377,7 @@ class AppServerClient:
     async def _send_json(self, payload: JsonDict) -> None:
         if self._transport is None:
             raise AppServerError("transport is not connected")
+        self._trace_protocol_message(stage="sent", payload=payload)
         await self._transport.send_json(payload)
 
     async def _receive_loop(self) -> None:
@@ -381,6 +385,7 @@ class AppServerClient:
         try:
             while self._transport is not None:
                 message = await self._transport.receive_json()
+                self._trace_protocol_message(stage="received", payload=message)
                 if self._dispatch_response(message):
                     continue
                 if self._dispatch_queue is not None:
@@ -467,6 +472,13 @@ class AppServerClient:
                 dispatcher_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await dispatcher_task
+        stderr_task = self._stderr_task
+        self._stderr_task = None
+        if stderr_task is not None and stderr_task is not asyncio.current_task():
+            if not stderr_task.done():
+                stderr_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await stderr_task
         transport = self._transport
         self._transport = None
         if transport is not None:
@@ -503,6 +515,49 @@ class AppServerClient:
         if method in _TRIMMED_THREAD_METHODS:
             self._trim_thread_history(result)
         return result
+
+    async def _drain_process_stderr(self, process: Any) -> None:
+        stderr = getattr(process, "stderr", None)
+        if stderr is None:
+            return
+        try:
+            while True:
+                line = await stderr.readline()
+                if not line:
+                    return
+                if isinstance(line, bytes):
+                    text = line.decode("utf-8", errors="replace").rstrip()
+                else:
+                    text = str(line).rstrip()
+                if not text:
+                    continue
+                emit_event(
+                    component="appserver.stderr",
+                    event="appserver.stderr.line",
+                    level="WARNING",
+                    message="App-server stderr output",
+                    data={"text": text},
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            emit_event(
+                component="appserver.stderr",
+                event="appserver.stderr.read_failed",
+                level="WARNING",
+                message="Failed while draining app-server stderr",
+                data={"error_type": type(exc).__name__},
+            )
+
+    def _trace_protocol_message(self, *, stage: str, payload: JsonDict) -> None:
+        emit_event(
+            component="appserver.protocol",
+            event=f"appserver.protocol.{stage}",
+            message=f"App-server protocol message {stage}",
+            connection_mode=self.connection_mode,
+            connection_epoch=self.connection_epoch,
+            data=summarize_transport_message(payload),
+        )
 
     def _trim_thread_history(self, result: JsonDict) -> None:
         thread = result.get("thread")

--- a/src/imcodex/appserver/protocol_map.py
+++ b/src/imcodex/appserver/protocol_map.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from typing import Any
 
 
@@ -20,10 +21,16 @@ class AppServerEvent:
 
 
 _EVENT_KINDS = {
+    "item/started": "item_started",
+    "item/mcpToolCall/progress": "mcp_tool_progress",
     "item/commandExecution/requestApproval": "approval_request",
     "item/fileChange/requestApproval": "approval_request",
+    "item/permissions/requestApproval": "approval_request",
     "item/tool/requestUserInput": "question_request",
     "item/agentMessage/delta": "agent_delta",
+    "item/reasoning/summaryTextDelta": "reasoning_summary_text_delta",
+    "item/reasoning/summaryPartAdded": "reasoning_summary_part_added",
+    "item/reasoning/textDelta": "reasoning_text_delta",
     "turn/started": "turn_started",
     "serverRequest/resolved": "request_resolved",
     "turn/plan/updated": "plan_updated",
@@ -100,6 +107,104 @@ def normalize_appserver_message(message: dict[str, Any]) -> AppServerEvent:
     )
 
 
+def summarize_transport_message(message: dict[str, Any], *, max_preview_chars: int = 240) -> dict[str, Any]:
+    transport_shape = _transport_shape(message)
+    summary: dict[str, Any] = {"transport_shape": transport_shape}
+
+    if transport_shape == "response":
+        summary["response_id"] = message.get("id")
+        if "error" in message:
+            summary["has_error"] = True
+            error = message.get("error")
+            if isinstance(error, dict):
+                summary["error_code"] = error.get("code")
+                summary["error_message"] = _trim_preview(str(error.get("message") or ""), max_preview_chars)
+            else:
+                summary["error_message"] = _trim_preview(str(error), max_preview_chars)
+        else:
+            result = message.get("result")
+            summary["has_error"] = False
+            if isinstance(result, dict):
+                summary["result_keys"] = sorted(result.keys())
+            else:
+                summary["result_type"] = type(result).__name__
+        return summary
+
+    if "method" not in message:
+        return summary
+
+    event = normalize_appserver_message(message)
+    payload = event.payload
+    item = payload.get("item") if isinstance(payload.get("item"), dict) else {}
+    turn = payload.get("turn") if isinstance(payload.get("turn"), dict) else {}
+    summary.update(
+        {
+            "method": event.method,
+            "category": event.category,
+            "kind": event.kind,
+            "direction": event.direction,
+            "thread_id": event.thread_id or None,
+            "turn_id": event.turn_id or None,
+            "item_id": event.item_id or None,
+            "request_id": event.request_id,
+            "payload_keys": sorted(payload.keys()),
+        }
+    )
+    if item:
+        summary["item_type"] = item.get("type")
+        if item.get("status") is not None:
+            summary["item_status"] = item.get("status")
+        if item.get("phase") is not None:
+            summary["item_phase"] = item.get("phase")
+    if turn:
+        if turn.get("status") is not None:
+            summary["turn_status"] = turn.get("status")
+        if turn.get("id") is not None:
+            summary["turn_payload_id"] = turn.get("id")
+    if "delta" in payload:
+        summary["delta_preview"] = _trim_preview(str(payload.get("delta") or ""), max_preview_chars)
+    if "summaryIndex" in payload:
+        summary["summary_index"] = payload.get("summaryIndex")
+    if "contentIndex" in payload:
+        summary["content_index"] = payload.get("contentIndex")
+    if "message" in payload:
+        summary["message_preview"] = _trim_preview(str(payload.get("message") or ""), max_preview_chars)
+    command = item.get("command") if item else payload.get("command")
+    if command:
+        summary["command"] = _trim_preview(str(command), max_preview_chars)
+    cwd = item.get("cwd") if item else payload.get("cwd")
+    if cwd:
+        summary["cwd"] = str(cwd)
+    if item and item.get("tool") is not None:
+        summary["tool"] = item.get("tool")
+    elif payload.get("tool") is not None:
+        summary["tool"] = payload.get("tool")
+    if item and item.get("server") is not None:
+        summary["server"] = item.get("server")
+    elif payload.get("server") is not None:
+        summary["server"] = payload.get("server")
+    if isinstance(payload.get("questions"), list):
+        questions = payload.get("questions") or []
+        summary["question_count"] = len(questions)
+        summary["questions"] = [
+            {
+                "id": question.get("id"),
+                "header": question.get("header"),
+                "question": _trim_preview(str(question.get("question") or ""), max_preview_chars),
+            }
+            for question in questions[:3]
+            if isinstance(question, dict)
+        ]
+    if item and item.get("changes") is not None and isinstance(item.get("changes"), list):
+        changes = [change.get("path") for change in item.get("changes", []) if isinstance(change, dict) and change.get("path")]
+        summary["changed_paths"] = changes[:10]
+    if isinstance(payload.get("permissions"), dict):
+        summary["permissions_keys"] = sorted((payload.get("permissions") or {}).keys())
+    if event.kind == "unknown":
+        summary["payload_preview"] = _trim_preview(_safe_json(payload), max_preview_chars)
+    return summary
+
+
 def _categorize_method(method: str) -> str:
     if method in _SYSTEM_METHODS:
         return "system"
@@ -113,3 +218,29 @@ def _string_or_none(value: Any) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+def _transport_shape(message: dict[str, Any]) -> str:
+    if "id" in message and ("result" in message or "error" in message):
+        return "response"
+    if "id" in message and "method" in message:
+        return "request"
+    if "method" in message:
+        return "notification"
+    return "unknown"
+
+
+def _trim_preview(value: str, max_chars: int) -> str:
+    text = " ".join(value.split())
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return text[:max_chars]
+    return text[: max_chars - 3] + "..."
+
+
+def _safe_json(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=True, sort_keys=True)
+    except Exception:
+        return repr(value)

--- a/src/imcodex/bridge/core.py
+++ b/src/imcodex/bridge/core.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import asyncio
 import json
 
-from ..appserver import AppServerError, StaleThreadBindingError, ThreadSelectionError
+from ..appserver import (
+    AppServerError,
+    StaleThreadBindingError,
+    ThreadSelectionError,
+    normalize_appserver_message,
+)
 from ..models import InboundMessage, OutboundMessage
 from ..observability.message_trace import ensure_trace_id, text_preview, text_sha256
 from ..observability.runtime import emit_event
@@ -283,8 +288,42 @@ class BridgeService:
         return await self._emit(message)
 
     async def handle_server_request(self, request: dict) -> list[OutboundMessage]:
+        event = normalize_appserver_message(request)
         message = self.projector.project_notification(request, self.store)
-        return await self._emit(message)
+        outbound = await self._emit(message)
+        if event.direction != "server_request":
+            return outbound
+        if event.request_id and self.store.get_pending_request(event.request_id) is not None:
+            return outbound
+        transport_request_id = self._transport_request_id(request)
+        if transport_request_id is not None:
+            await self.backend.reply_error_to_transport_request(
+                transport_request_id,
+                code=-32601,
+                message=f"unsupported or unroutable server request: {event.method}",
+                data={
+                    "reason": "unsupportedServerRequest",
+                    "method": event.method,
+                    "requestId": event.request_id,
+                },
+            )
+        emit_event(
+            component="bridge",
+            event="bridge.server_request.rejected",
+            level="WARNING",
+            message="Rejected unsupported or unroutable server request",
+            data={
+                "method": event.method,
+                "request_id": event.request_id,
+                "thread_id": event.thread_id,
+                "turn_id": event.turn_id,
+            },
+        )
+        warning = self._server_request_rejection_message(event)
+        if warning is None:
+            return outbound
+        outbound.extend(await self._emit(warning))
+        return outbound
 
     async def handle_connection_reset(self, connection_epoch: int) -> None:
         routes = self.store.invalidate_pending_requests_for_connection(connection_epoch)
@@ -612,8 +651,10 @@ class BridgeService:
         continue_on_failure: bool,
     ) -> list[OutboundMessage] | None:
         for request_id in request_ids:
+            route = self.store.get_pending_request(request_id)
+            payload = self._projected_request_resolution(route, decision)
             try:
-                await self.backend.reply_to_server_request(request_id, {"decision": decision})
+                await self.backend.reply_to_server_request(request_id, payload)
             except (AppServerError, KeyError) as exc:
                 failure = await self._request_reply_failure(inbound, request_id, action, exc)
                 if not continue_on_failure:
@@ -695,3 +736,37 @@ class BridgeService:
         if len(text) > 180:
             return "unexpected upstream error"
         return text
+
+    def _projected_request_resolution(self, route, decision: str) -> dict:
+        if route is None:
+            return {"decision": decision}
+        if route.request_method == "item/permissions/requestApproval":
+            permissions = route.payload.get("permissions")
+            granted = permissions if decision == "accept" and isinstance(permissions, dict) else {}
+            return {"permissions": granted}
+        return {"decision": decision}
+
+    def _server_request_rejection_message(self, event) -> OutboundMessage | None:
+        if not event.thread_id:
+            return None
+        binding = self.store.find_binding_by_thread_id(event.thread_id)
+        if binding is None:
+            return None
+        text = (
+            f"{_SYSTEM_PREFIX}Codex sent an unsupported or unroutable request "
+            f"(`{event.method}`), so I rejected it to avoid leaving the turn stuck."
+        )
+        return OutboundMessage(
+            channel_id=binding.channel_id,
+            conversation_id=binding.conversation_id,
+            message_type="status",
+            text=text,
+        )
+
+    def _transport_request_id(self, request: dict) -> str | int | None:
+        params = request.get("params")
+        if isinstance(params, dict):
+            transport_request_id = params.get("_transport_request_id")
+            if transport_request_id is not None:
+                return transport_request_id
+        return request.get("id")

--- a/src/imcodex/bridge/projection.py
+++ b/src/imcodex/bridge/projection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from ..appserver import normalize_appserver_message
 from ..models import OutboundMessage
 from .message_pump import MessagePump
@@ -202,6 +204,7 @@ class MessageProjector:
         command = str(route.payload.get("command") or "").strip()
         cwd = str(route.payload.get("cwd") or "").strip()
         path = str(route.payload.get("path") or "").strip()
+        permissions = route.payload.get("permissions")
         if reason:
             lines.append(reason)
         if command:
@@ -210,6 +213,10 @@ class MessageProjector:
             lines.append(f"CWD: {cwd}")
         if path:
             lines.append(f"Path: {path}")
+        if isinstance(permissions, dict) and permissions:
+            rendered_permissions = json.dumps(permissions, ensure_ascii=True, indent=2, sort_keys=True)
+            lines.append("Permissions:")
+            lines.append(rendered_permissions)
         lines.append("Use /approve to allow, /deny to reject, or send a new message to cancel and continue.")
         lines.append(f"Target one request with /approve {handle}, /deny {handle}, or /cancel {handle}.")
         text = "\n".join(lines)

--- a/src/imcodex/core_manager.py
+++ b/src/imcodex/core_manager.py
@@ -22,6 +22,9 @@ class DedicatedCoreManifest:
     url: str
     started_at: str
     status: str
+    command: list[str] | None = None
+    stdout_log: str | None = None
+    stderr_log: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -34,6 +37,9 @@ class DedicatedCoreManifest:
             url=str(payload["url"]),
             started_at=str(payload["started_at"]),
             status=str(payload["status"]),
+            command=list(payload["command"]) if isinstance(payload.get("command"), list) else None,
+            stdout_log=str(payload["stdout_log"]) if payload.get("stdout_log") is not None else None,
+            stderr_log=str(payload["stderr_log"]) if payload.get("stderr_log") is not None else None,
         )
 
 
@@ -61,8 +67,13 @@ class DedicatedCoreManager:
     def start(self, *, port: int) -> DedicatedCoreManifest:
         self.root.mkdir(parents=True, exist_ok=True)
         url = f"ws://127.0.0.1:{port}"
+        command = [self.codex_bin, "app-server", "--listen", url]
+        stdout_log = self.root / "core.stdout.log"
+        stderr_log = self.root / "core.stderr.log"
+        stdout_log.write_text("", encoding="utf-8")
+        stderr_log.write_text("", encoding="utf-8")
         process = self.launcher(
-            command=[self.codex_bin, "app-server", "--listen", url],
+            command=command,
             cwd=self.repo_root,
             env=os.environ.copy(),
         )
@@ -73,6 +84,9 @@ class DedicatedCoreManager:
             url=url,
             started_at=self.now(),
             status="running",
+            command=command,
+            stdout_log=str(stdout_log),
+            stderr_log=str(stderr_log),
         )
         self.manifest_path.write_text(json.dumps(manifest.to_dict(), ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
         return manifest
@@ -109,13 +123,16 @@ class DedicatedCoreManager:
 
     def _default_launcher(self, *, command: list[str], cwd: Path, env: dict[str, str]) -> object:
         resolved = self._resolve_command(command)
-        return subprocess.Popen(
-            resolved,
-            cwd=str(cwd),
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        stdout_path = self.root / "core.stdout.log"
+        stderr_path = self.root / "core.stderr.log"
+        with stdout_path.open("ab") as stdout_handle, stderr_path.open("ab") as stderr_handle:
+            return subprocess.Popen(
+                resolved,
+                cwd=str(cwd),
+                env=env,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+            )
 
     def _default_now(self) -> str:
         from datetime import datetime, timezone

--- a/tests/test_appserver_stdio.py
+++ b/tests/test_appserver_stdio.py
@@ -234,6 +234,26 @@ async def test_stdio_client_initializes_dispatches_notifications_and_replies_to_
 
     await client.reply_to_transport_request(99, {"answers": {"color": {"answers": ["blue"]}}})
 
+    assert process.sent[0] == {
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "clientInfo": {"name": "imcodex", "title": "IMCodex", "version": "0.1.0"},
+            "capabilities": {
+                "optOutNotificationMethods": [
+                    "command/exec/outputDelta",
+                    "item/agentMessage/delta",
+                    "item/plan/delta",
+                    "item/commandExecution/outputDelta",
+                    "item/fileChange/outputDelta",
+                    "item/reasoning/summaryTextDelta",
+                    "item/reasoning/textDelta",
+                    "thread/realtime/transcript/delta",
+                    "thread/realtime/outputAudio/delta",
+                ]
+            },
+        },
+    }
     assert process.sent[-1] == {
         "id": 99,
         "result": {"answers": {"color": {"answers": ["blue"]}}},
@@ -618,11 +638,19 @@ async def test_client_emits_observability_events_for_shared_websocket_connection
 
     await client.list_threads()
 
-    assert [event["event"] for event in observed_events] == [
+    event_names = [event["event"] for event in observed_events]
+    assert event_names[:2] == [
         "appserver.connect.started",
         "appserver.connect.websocket_succeeded",
     ]
+    assert event_names.count("appserver.protocol.sent") == 3
+    assert event_names.count("appserver.protocol.received") == 2
     assert observed_health[-1] == {"connected": True, "mode": "shared-ws"}
+    sent = [event for event in observed_events if event["event"] == "appserver.protocol.sent"]
+    received = [event for event in observed_events if event["event"] == "appserver.protocol.received"]
+    assert sent[0]["data"]["method"] == "initialize"
+    assert received[-1]["data"]["response_id"] == 2
+    assert received[-1]["data"]["transport_shape"] == "response"
     await client.close()
 
 
@@ -667,11 +695,89 @@ async def test_client_reports_dedicated_ws_mode_for_dedicated_websocket_connecti
 
     assert captured_urls == ["ws://127.0.0.1:9001"]
     assert client.connection_mode == "dedicated-ws"
-    assert [event["event"] for event in observed_events] == [
+    event_names = [event["event"] for event in observed_events]
+    assert event_names[:2] == [
         "appserver.connect.started",
         "appserver.connect.websocket_succeeded",
     ]
     assert observed_health[-1] == {"connected": True, "mode": "dedicated-ws"}
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_logs_reasoning_and_server_request_protocol_messages(monkeypatch) -> None:
+    observed_events: list[dict] = []
+
+    def capture_event(**payload) -> None:
+        observed_events.append(payload)
+
+    monkeypatch.setattr("imcodex.appserver.client.emit_event", capture_event)
+    monkeypatch.setattr("imcodex.appserver.client.mark_appserver_health", lambda **_payload: None)
+
+    process = ScriptedProcess(
+        {
+            "initialize": [{"id": 1, "result": {"ok": True}}],
+            "thread/start": [
+                {
+                    "id": 2,
+                    "result": {
+                        "thread": {
+                            "id": "thr_1",
+                            "cwd": "D:/repo/app",
+                            "preview": "seed",
+                            "status": "idle",
+                        }
+                    },
+                },
+                {
+                    "method": "item/reasoning/summaryTextDelta",
+                    "params": {
+                        "threadId": "thr_1",
+                        "turnId": "turn_1",
+                        "itemId": "item_reasoning",
+                        "summaryIndex": 0,
+                        "delta": "thinking through the repository state",
+                    },
+                },
+                {
+                    "id": 99,
+                    "method": "item/permissions/requestApproval",
+                    "params": {
+                        "requestId": "native-request-abcdef",
+                        "threadId": "thr_1",
+                        "turnId": "turn_1",
+                        "itemId": "item_perm",
+                        "reason": "Need broader access",
+                        "permissions": {"network": {"enabled": True}},
+                    },
+                },
+            ],
+        }
+    )
+    supervisor = AppServerSupervisor(
+        codex_bin="codex",
+        core_mode="spawned-stdio",
+        spawn_process=lambda *args: process,
+    )
+    client = AppServerClient(
+        supervisor=supervisor,
+        client_info={"name": "imcodex", "title": "IMCodex", "version": "0.1.0"},
+    )
+    captured_requests: list[dict] = []
+    client.add_server_request_handler(captured_requests.append)
+
+    await client.start_thread(cwd="D:/repo/app")
+    await asyncio.sleep(0)
+
+    received = [event for event in observed_events if event["event"] == "appserver.protocol.received"]
+    reasoning = next(event for event in received if event["data"].get("method") == "item/reasoning/summaryTextDelta")
+    approval = next(event for event in received if event["data"].get("method") == "item/permissions/requestApproval")
+
+    assert reasoning["data"]["kind"] == "reasoning_summary_text_delta"
+    assert reasoning["data"]["delta_preview"] == "thinking through the repository state"
+    assert approval["data"]["kind"] == "approval_request"
+    assert approval["data"]["request_id"] == "native-request-abcdef"
+    assert captured_requests[0]["method"] == "item/permissions/requestApproval"
     await client.close()
 
 

--- a/tests/test_core_manager.py
+++ b/tests/test_core_manager.py
@@ -42,10 +42,17 @@ def test_core_manager_start_writes_manifest_and_uses_ws_listener(tmp_path: Path)
     assert manifest.pid == 42001
     assert manifest.port == 8765
     assert manifest.url == "ws://127.0.0.1:8765"
+    assert manifest.command == ["codex", "app-server", "--listen", "ws://127.0.0.1:8765"]
+    assert manifest.stdout_log is not None
+    assert manifest.stderr_log is not None
     assert launched["command"] == ["codex", "app-server", "--listen", "ws://127.0.0.1:8765"]
     saved = json.loads((tmp_path / "core-lab" / "core.json").read_text(encoding="utf-8"))
     assert saved["url"] == "ws://127.0.0.1:8765"
     assert saved["status"] == "running"
+    assert saved["stdout_log"].endswith("core.stdout.log")
+    assert saved["stderr_log"].endswith("core.stderr.log")
+    assert (tmp_path / "core-lab" / "core.stdout.log").exists()
+    assert (tmp_path / "core-lab" / "core.stderr.log").exists()
 
 
 def test_core_manager_stop_updates_manifest(tmp_path: Path) -> None:

--- a/tests/test_service_e2e.py
+++ b/tests/test_service_e2e.py
@@ -585,6 +585,117 @@ async def test_connection_ready_rehydrates_bound_thread_and_replays_native_appro
 
 
 @pytest.mark.asyncio
+async def test_permission_request_is_projected_and_approve_grants_requested_permissions() -> None:
+    process = ScriptedProcess({"initialize": [{"id": 1, "result": {"ok": True}}]})
+    store = ConversationStore(clock=lambda: 1.0)
+    store.set_bootstrap_cwd("qq", "conv-1", r"D:\work\alpha")
+    store.bind_thread("qq", "conv-1", "thr_1")
+    sink = CapturingSink()
+    client, service = _build_service(store, process, sink)
+
+    projected = await service.handle_server_request(
+        {
+            "id": 91,
+            "method": "item/permissions/requestApproval",
+            "params": {
+                "_request_id": "native-request-perms",
+                "_transport_request_id": 91,
+                "threadId": "thr_1",
+                "turnId": "turn_1",
+                "reason": "Need access outside the workspace root",
+                "permissions": {
+                    "fileSystem": {
+                        "read": [r"D:\desktop\codex-upstream"],
+                    }
+                },
+            },
+        }
+    )
+
+    assert projected[0].message_type == "approval_request"
+    assert "Permissions:" in projected[0].text
+    assert "fileSystem" in projected[0].text
+
+    messages = await service.handle_inbound(
+        InboundMessage(
+            channel_id="qq",
+            conversation_id="conv-1",
+            user_id="u1",
+            message_id="m1",
+            text="/approve",
+        )
+    )
+
+    assert messages[0].message_type == "status"
+    reply_payloads = [
+        payload
+        for payload in process.inputs
+        if "result" in payload and payload.get("id") == 91
+    ]
+    assert reply_payloads == [
+        {
+            "id": 91,
+            "result": {
+                "permissions": {
+                    "fileSystem": {
+                        "read": [r"D:\desktop\codex-upstream"],
+                    }
+                }
+            },
+        }
+    ]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_unhandled_server_request_is_rejected_instead_of_silently_stalling() -> None:
+    process = ScriptedProcess({"initialize": [{"id": 1, "result": {"ok": True}}]})
+    store = ConversationStore(clock=lambda: 1.0)
+    store.set_bootstrap_cwd("qq", "conv-1", r"D:\work\alpha")
+    store.bind_thread("qq", "conv-1", "thr_1")
+    sink = CapturingSink()
+    client, service = _build_service(store, process, sink)
+
+    projected = await service.handle_server_request(
+        {
+            "id": 77,
+            "method": "item/tool/call",
+            "params": {
+                "_request_id": "native-request-tool",
+                "_transport_request_id": 77,
+                "threadId": "thr_1",
+                "turnId": "turn_1",
+                "tool": "lookup_ticket",
+                "arguments": {"id": "ABC-123"},
+            },
+        }
+    )
+
+    assert projected[0].message_type == "status"
+    assert "unsupported or unroutable request" in projected[0].text
+    error_payloads = [
+        payload
+        for payload in process.inputs
+        if "error" in payload and payload.get("id") == 77
+    ]
+    assert error_payloads == [
+        {
+            "id": 77,
+            "error": {
+                "code": -32601,
+                "message": "unsupported or unroutable server request: item/tool/call",
+                "data": {
+                    "reason": "unsupportedServerRequest",
+                    "method": "item/tool/call",
+                    "requestId": "native-request-tool",
+                },
+            },
+        }
+    ]
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_connection_reset_evicts_stale_pending_requests_and_interrupts_turn() -> None:
     process = ScriptedProcess(
         {


### PR DESCRIPTION
## Summary

- Add structured app-server protocol tracing and stdio/core log capture for troubleshooting.
- Summarize transport messages without logging full payloads, including reasoning, approval, response, and tool metadata.
- Handle native permissions approvals and reject unsupported or unroutable server requests so turns do not silently stall.

## Notes

This branch was rebuilt on top of the latest `origin/main` and preserves the mainline dispatcher, dedicated websocket mode, and stale-turn recovery changes.

## Validation

- `python -m pytest` -> 178 passed
