### PR TITLE
[codex] Preserve local appserver protocol diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ IMCODEX_LOG_LEVEL=INFO
 IMCODEX_HTTP_HOST=0.0.0.0
 IMCODEX_HTTP_PORT=8000
 IMCODEX_SERVICE_NAME=imcodex
+# Local-only raw app-server protocol logging for deep debugging. May contain sensitive payloads.
+IMCODEX_RAW_PROTOCOL_LOG=0
 
 # Optional outbound webhook
 # IMCODEX_OUTBOUND_URL=https://your-adapter.example/api/outbound

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Codex version requirement:
 - `IMCODEX_CORE_URL`: optional dedicated Codex core websocket URL
 - `IMCODEX_RESTART_EXECUTOR`: optional bridge restart command
 - `IMCODEX_DEBUG_API_ENABLED`: enable debug HTTP routes, default `false`
+- `IMCODEX_RAW_PROTOCOL_LOG`: write local-only raw app-server protocol logs, default `false`
 - `IMCODEX_LOG_LEVEL`: Python logging level, default `INFO`
 - `IMCODEX_HTTP_HOST`: HTTP bind host, default `0.0.0.0`
 - `IMCODEX_HTTP_PORT`: HTTP bind port, default `8000`

--- a/docs/startup.md
+++ b/docs/startup.md
@@ -46,6 +46,12 @@ bridge. The summaries include transport shape, method names, request ids,
 thread and turn ids, and short previews for diagnostic fields, but they avoid
 recording full native payloads.
 
+For local-only deep protocol debugging, set `IMCODEX_RAW_PROTOCOL_LOG=1` before
+startup. This writes raw app-server transport messages to
+`.imcodex-run/current/raw-protocol.jsonl` and the archived run directory. The
+file is intended for local diagnosis only; it may contain user prompts, tool
+arguments, paths, connector data, or other sensitive native payload content.
+
 ### Supported: externally managed websocket core
 
 If another process already owns a websocket Codex core, point the bridge at it

--- a/src/imcodex/appserver/client.py
+++ b/src/imcodex/appserver/client.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
 from .diagnostics import summarize_text, summarize_transport_message
-from ..observability.runtime import emit_event, mark_appserver_health
+from ..observability.runtime import emit_event, mark_appserver_health, write_raw_protocol_message
 
 
 JsonDict = dict[str, Any]
@@ -550,6 +550,12 @@ class AppServerClient:
             )
 
     def _trace_protocol_message(self, *, stage: str, payload: JsonDict) -> None:
+        write_raw_protocol_message(
+            stage=stage,
+            connection_mode=self.connection_mode,
+            connection_epoch=self.connection_epoch,
+            payload=payload,
+        )
         emit_event(
             component="appserver.protocol",
             event=f"appserver.protocol.{stage}",

--- a/src/imcodex/appserver/diagnostics.py
+++ b/src/imcodex/appserver/diagnostics.py
@@ -88,6 +88,20 @@ def summarize_transport_message(message: dict[str, Any], *, max_preview_chars: i
         summary["content_index"] = payload.get("contentIndex")
     if "message" in payload:
         summary["message_preview"] = _trim_preview(str(payload.get("message") or ""), max_preview_chars)
+    error = payload.get("error")
+    if isinstance(error, dict):
+        if error.get("type") is not None:
+            summary["error_type"] = str(error.get("type"))
+        if error.get("code") is not None:
+            summary["error_code"] = error.get("code")
+        if error.get("status") is not None:
+            summary["error_status"] = error.get("status")
+        if error.get("message") is not None:
+            summary["error_message"] = _trim_preview(str(error.get("message") or ""), max_preview_chars)
+    elif error is not None:
+        summary["error_message"] = _trim_preview(str(error), max_preview_chars)
+    if payload.get("status") is not None:
+        summary["status"] = payload.get("status")
     command = item.get("command") if item else payload.get("command")
     if command:
         summary["command"] = _trim_preview(str(command), max_preview_chars)

--- a/src/imcodex/appserver/protocol_map.py
+++ b/src/imcodex/appserver/protocol_map.py
@@ -40,6 +40,7 @@ _EVENT_KINDS = {
     "thread/status/changed": "thread_status_changed",
     "thread/compacted": "thread_compacted",
     "model/rerouted": "model_rerouted",
+    "error": "error",
     "configWarning": "config_warning",
     "deprecationNotice": "deprecation_notice",
 }

--- a/src/imcodex/composition.py
+++ b/src/imcodex/composition.py
@@ -47,6 +47,7 @@ def build_runtime(settings: Settings | None = None) -> AppRuntime:
         http_port=settings.http_port,
         app_server_url=settings.core_url or settings.app_server_url,
         cwd=Path.cwd(),
+        raw_protocol_log_enabled=settings.raw_protocol_log_enabled,
     )
     observability.write_launch_snapshot(
         command=["python", "-m", "imcodex"],
@@ -61,6 +62,7 @@ def build_runtime(settings: Settings | None = None) -> AppRuntime:
             "IMCODEX_CORE_URL": settings.core_url or "",
             "IMCODEX_RESTART_EXECUTOR": settings.restart_executor or "",
             "IMCODEX_DEBUG_API_ENABLED": "1" if settings.debug_api_enabled else "0",
+            "IMCODEX_RAW_PROTOCOL_LOG": "1" if settings.raw_protocol_log_enabled else "0",
             "IMCODEX_QQ_ENABLED": "1" if settings.qq_enabled else "0",
             "IMCODEX_QQ_APP_ID": settings.qq_app_id,
             "IMCODEX_QQ_CLIENT_SECRET": settings.qq_client_secret,

--- a/src/imcodex/config.py
+++ b/src/imcodex/config.py
@@ -44,6 +44,7 @@ class Settings:
     http_port: int
     outbound_url: str | None
     service_name: str
+    raw_protocol_log_enabled: bool
     qq_enabled: bool
     qq_app_id: str
     qq_client_secret: str
@@ -76,6 +77,7 @@ class Settings:
             http_port=int(_env("IMCODEX_HTTP_PORT", "8000", dotenv)),
             outbound_url=_env("IMCODEX_OUTBOUND_URL", "", dotenv) or None,
             service_name=_env("IMCODEX_SERVICE_NAME", "imcodex", dotenv),
+            raw_protocol_log_enabled=_env_bool("IMCODEX_RAW_PROTOCOL_LOG", False, dotenv),
             qq_enabled=_env_bool("IMCODEX_QQ_ENABLED", False, dotenv),
             qq_app_id=_env("IMCODEX_QQ_APP_ID", "", dotenv),
             qq_client_secret=_env("IMCODEX_QQ_CLIENT_SECRET", "", dotenv),

--- a/src/imcodex/observability/paths.py
+++ b/src/imcodex/observability/paths.py
@@ -16,6 +16,8 @@ class ObservabilityPaths:
     current_log_path: Path
     events_path: Path
     current_events_path: Path
+    raw_protocol_path: Path
+    current_raw_protocol_path: Path
     health_path: Path
     current_health_path: Path
     launch_path: Path
@@ -37,6 +39,8 @@ class ObservabilityPaths:
             current_log_path=current_dir / "bridge.log",
             events_path=instance_dir / "events.jsonl",
             current_events_path=current_dir / "events.jsonl",
+            raw_protocol_path=instance_dir / "raw-protocol.jsonl",
+            current_raw_protocol_path=current_dir / "raw-protocol.jsonl",
             health_path=instance_dir / "health.json",
             current_health_path=current_dir / "health.json",
             launch_path=instance_dir / "launch.json",

--- a/src/imcodex/observability/raw_protocol.py
+++ b/src/imcodex/observability/raw_protocol.py
@@ -17,7 +17,7 @@ class RawProtocolWriter:
         self.clock = clock
         self._lock = Lock()
         self._state_lock = Lock()
-        self._queue: Queue[dict[str, Any] | None] = Queue()
+        self._queue: Queue[str | None] = Queue()
         self._closed = False
         for path in (self.paths.raw_protocol_path, self.paths.current_raw_protocol_path):
             path.touch(exist_ok=True)
@@ -41,10 +41,14 @@ class RawProtocolWriter:
             "connection_epoch": connection_epoch,
             "payload": payload,
         }
+        try:
+            serialized = json.dumps(record, ensure_ascii=False)
+        except Exception:
+            return
         with self._state_lock:
             if self._closed:
                 return
-            self._queue.put(record)
+            self._queue.put(serialized)
 
     def flush(self) -> None:
         self._queue.join()
@@ -60,12 +64,12 @@ class RawProtocolWriter:
 
     def _write_loop(self) -> None:
         while True:
-            record = self._queue.get()
+            serialized = self._queue.get()
             try:
-                if record is None:
+                if serialized is None:
                     return
                 try:
-                    self._write_payload(json.dumps(record, ensure_ascii=False))
+                    self._write_payload(serialized)
                 except Exception:
                     pass
             finally:

--- a/src/imcodex/observability/raw_protocol.py
+++ b/src/imcodex/observability/raw_protocol.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from queue import Queue
+from threading import Lock
+from threading import Thread
+from typing import Any
+
+from .context import InstanceContext
+from .paths import ObservabilityPaths
+
+
+class RawProtocolWriter:
+    def __init__(self, *, paths: ObservabilityPaths, context: InstanceContext, clock) -> None:
+        self.paths = paths
+        self.context = context
+        self.clock = clock
+        self._lock = Lock()
+        self._state_lock = Lock()
+        self._queue: Queue[dict[str, Any] | None] = Queue()
+        self._closed = False
+        for path in (self.paths.raw_protocol_path, self.paths.current_raw_protocol_path):
+            path.touch(exist_ok=True)
+        self._thread = Thread(target=self._write_loop, name="imcodex-raw-protocol-writer", daemon=True)
+        self._thread.start()
+
+    def emit(
+        self,
+        *,
+        stage: str,
+        connection_mode: str,
+        connection_epoch: int,
+        payload: dict[str, Any],
+    ) -> None:
+        record = {
+            "ts": self.clock().astimezone().isoformat(),
+            "stage": stage,
+            "instance_id": self.context.instance_id,
+            "pid": self.context.pid,
+            "connection_mode": connection_mode,
+            "connection_epoch": connection_epoch,
+            "payload": payload,
+        }
+        with self._state_lock:
+            if self._closed:
+                return
+            self._queue.put(record)
+
+    def flush(self) -> None:
+        self._queue.join()
+
+    def close(self) -> None:
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(None)
+        self._queue.join()
+        self._thread.join(timeout=1)
+
+    def _write_loop(self) -> None:
+        while True:
+            record = self._queue.get()
+            try:
+                if record is None:
+                    return
+                try:
+                    self._write_payload(json.dumps(record, ensure_ascii=False))
+                except Exception:
+                    pass
+            finally:
+                self._queue.task_done()
+
+    def _write_payload(self, payload: str) -> None:
+        with self._lock:
+            for path in (self.paths.raw_protocol_path, self.paths.current_raw_protocol_path):
+                with path.open("a", encoding="utf-8") as handle:
+                    handle.write(payload + "\n")

--- a/src/imcodex/observability/runtime.py
+++ b/src/imcodex/observability/runtime.py
@@ -14,6 +14,7 @@ from .events import EventWriter
 from .health import HealthWriter
 from .logger import configure_observability_logging, reset_observability_logging
 from .paths import ObservabilityPaths
+from .raw_protocol import RawProtocolWriter
 
 _ACTIVE_RUNTIME: "ObservabilityRuntime | None" = None
 
@@ -33,6 +34,7 @@ class ObservabilityRuntime:
         pid_provider: Callable[[], int] | None = None,
         git_metadata_provider: Callable[[Path], dict[str, str]] | None = None,
         retention: int = 20,
+        raw_protocol_log_enabled: bool = False,
     ) -> None:
         self.run_root = Path(run_root)
         self.service_name = service_name
@@ -45,10 +47,12 @@ class ObservabilityRuntime:
         self.pid_provider = pid_provider or os.getpid
         self.git_metadata_provider = git_metadata_provider or _read_git_metadata
         self.retention = retention
+        self.raw_protocol_log_enabled = raw_protocol_log_enabled
         self.instance_id = ""
         self.context: InstanceContext | None = None
         self.paths: ObservabilityPaths | None = None
         self.event_writer: EventWriter | None = None
+        self.raw_protocol_writer: RawProtocolWriter | None = None
         self.health_writer: HealthWriter | None = None
         self._pending_launch_snapshot: dict[str, Any] | None = None
 
@@ -80,6 +84,8 @@ class ObservabilityRuntime:
             log_paths=[self.paths.log_path, self.paths.current_log_path],
         )
         self.event_writer = EventWriter(paths=self.paths, context=self.context, clock=self.clock)
+        if self.raw_protocol_log_enabled:
+            self.raw_protocol_writer = RawProtocolWriter(paths=self.paths, context=self.context, clock=self.clock)
         self.health_writer = HealthWriter(paths=self.paths, context=self.context, clock=self.clock)
         if self._pending_launch_snapshot is not None:
             self._persist_launch_snapshot(self._pending_launch_snapshot)
@@ -89,6 +95,8 @@ class ObservabilityRuntime:
     def stop(self) -> None:
         if self.event_writer is not None:
             self.event_writer.close()
+        if self.raw_protocol_writer is not None:
+            self.raw_protocol_writer.close()
         if self.health_writer is not None:
             self.health_writer.update(status="stopped")
         reset_observability_logging()
@@ -119,6 +127,23 @@ class ObservabilityRuntime:
         if self.health_writer is None:
             return
         self.health_writer.update(**changes)
+
+    def write_raw_protocol_message(
+        self,
+        *,
+        stage: str,
+        connection_mode: str,
+        connection_epoch: int,
+        payload: dict[str, Any],
+    ) -> None:
+        if self.raw_protocol_writer is None:
+            return
+        self.raw_protocol_writer.emit(
+            stage=stage,
+            connection_mode=connection_mode,
+            connection_epoch=connection_epoch,
+            payload=payload,
+        )
 
     def mark_channel_health(self, channel_id: str, **changes: Any) -> None:
         if self.health_writer is None:
@@ -217,6 +242,23 @@ def emit_event(
             message=message,
             data=data,
             **fields,
+        )
+
+
+def write_raw_protocol_message(
+    *,
+    stage: str,
+    connection_mode: str,
+    connection_epoch: int,
+    payload: dict[str, Any],
+) -> None:
+    runtime = get_active_runtime()
+    if runtime is not None:
+        runtime.write_raw_protocol_message(
+            stage=stage,
+            connection_mode=connection_mode,
+            connection_epoch=connection_epoch,
+            payload=payload,
         )
 
 

--- a/tests/test_appserver_stdio.py
+++ b/tests/test_appserver_stdio.py
@@ -590,6 +590,7 @@ async def test_client_uses_explicit_websocket_app_server_before_spawning() -> No
 async def test_client_emits_observability_events_for_shared_websocket_connection(monkeypatch) -> None:
     observed_events: list[dict] = []
     observed_health: list[dict] = []
+    raw_protocol: list[dict] = []
 
     def capture_event(**payload) -> None:
         observed_events.append(payload)
@@ -599,6 +600,10 @@ async def test_client_emits_observability_events_for_shared_websocket_connection
 
     monkeypatch.setattr("imcodex.appserver.client.emit_event", capture_event)
     monkeypatch.setattr("imcodex.appserver.client.mark_appserver_health", capture_health)
+    monkeypatch.setattr(
+        "imcodex.appserver.client.write_raw_protocol_message",
+        lambda **payload: raw_protocol.append(payload),
+    )
 
     websocket = ScriptedWebSocket(
         {
@@ -631,6 +636,10 @@ async def test_client_emits_observability_events_for_shared_websocket_connection
     assert received[-1]["data"]["response_id"] == 2
     assert received[-1]["data"]["transport_shape"] == "response"
     assert observed_health[-1] == {"connected": True, "mode": "shared-ws"}
+    assert raw_protocol[0]["stage"] == "sent"
+    assert raw_protocol[0]["payload"]["method"] == "initialize"
+    assert raw_protocol[-1]["stage"] == "received"
+    assert raw_protocol[-1]["payload"]["result"] == {"threads": []}
     await client.close()
 
 

--- a/tests/test_appserver_stdio.py
+++ b/tests/test_appserver_stdio.py
@@ -811,6 +811,33 @@ def test_unknown_protocol_summary_does_not_serialize_payload_content() -> None:
     assert "secret message body" not in str(summary)
 
 
+def test_error_protocol_summary_preserves_bounded_error_message() -> None:
+    summary = summarize_transport_message(
+        {
+            "method": "error",
+            "params": {
+                "threadId": "thr_1",
+                "turnId": "turn_1",
+                "status": 400,
+                "terminal": True,
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade.",
+                },
+            },
+        }
+    )
+
+    assert summary["kind"] == "error"
+    assert summary["category"] == "system"
+    assert summary["thread_id"] == "thr_1"
+    assert summary["turn_id"] == "turn_1"
+    assert summary["status"] == 400
+    assert summary["error_type"] == "invalid_request_error"
+    assert summary["error_message"] == "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade."
+    assert "payload_key_fingerprints" not in summary
+
+
 @pytest.mark.asyncio
 async def test_stderr_diagnostics_emit_bounded_summary(monkeypatch) -> None:
     observed_events: list[dict] = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,16 @@ def test_settings_reads_optional_debug_api_flag_from_env(monkeypatch, tmp_path) 
     assert settings.debug_api_enabled is True
 
 
+def test_settings_reads_raw_protocol_log_flag_from_env(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("IMCODEX_RAW_PROTOCOL_LOG", "1")
+
+    settings = Settings.from_env()
+    monkeypatch.chdir(Path(__file__).resolve().parents[1])
+
+    assert settings.raw_protocol_log_enabled is True
+
+
 def test_settings_reads_core_mode_and_restart_executor(monkeypatch, tmp_path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("IMCODEX_CORE_MODE", "dedicated-ws")

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -100,6 +100,66 @@ def test_observability_runtime_writes_structured_events_to_archive_and_current(t
     runtime.stop()
 
 
+def test_observability_runtime_writes_raw_protocol_only_when_enabled(tmp_path: Path) -> None:
+    disabled = ObservabilityRuntime(
+        run_root=tmp_path / "disabled",
+        service_name="imcodex",
+        log_level="INFO",
+        http_host="0.0.0.0",
+        http_port=8000,
+        app_server_url=None,
+        cwd=Path(r"D:\desktop\imcodex"),
+        clock=_clock,
+        pid_provider=lambda: 48648,
+        git_metadata_provider=lambda cwd: {"git_branch": "main", "git_commit": "abc1234"},
+    )
+
+    disabled.start()
+    disabled.write_raw_protocol_message(
+        stage="received",
+        connection_mode="spawned-stdio",
+        connection_epoch=1,
+        payload={"method": "error", "params": {"error": {"message": "secret raw value"}}},
+    )
+    assert not disabled.paths.raw_protocol_path.exists()
+    assert not disabled.paths.current_raw_protocol_path.exists()
+    disabled.stop()
+
+    enabled = ObservabilityRuntime(
+        run_root=tmp_path / "enabled",
+        service_name="imcodex",
+        log_level="INFO",
+        http_host="0.0.0.0",
+        http_port=8000,
+        app_server_url=None,
+        cwd=Path(r"D:\desktop\imcodex"),
+        clock=_clock,
+        pid_provider=lambda: 48648,
+        git_metadata_provider=lambda cwd: {"git_branch": "main", "git_commit": "abc1234"},
+        raw_protocol_log_enabled=True,
+    )
+
+    enabled.start()
+    enabled.write_raw_protocol_message(
+        stage="received",
+        connection_mode="spawned-stdio",
+        connection_epoch=1,
+        payload={"method": "error", "params": {"error": {"message": "secret raw value"}}},
+    )
+    assert enabled.raw_protocol_writer is not None
+    enabled.raw_protocol_writer.flush()
+
+    archived = json.loads(enabled.paths.raw_protocol_path.read_text(encoding="utf-8").strip())
+    current = json.loads(enabled.paths.current_raw_protocol_path.read_text(encoding="utf-8").strip())
+
+    assert archived == current
+    assert archived["stage"] == "received"
+    assert archived["connection_mode"] == "spawned-stdio"
+    assert archived["connection_epoch"] == 1
+    assert archived["payload"]["params"]["error"]["message"] == "secret raw value"
+    enabled.stop()
+
+
 def test_event_writer_flushes_events_from_background_writer(tmp_path: Path) -> None:
     paths = ObservabilityPaths.build(tmp_path, "instance-1")
     paths.instance_dir.mkdir(parents=True)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from imcodex.observability.context import InstanceContext
 from imcodex.observability.events import EventWriter
 from imcodex.observability.paths import ObservabilityPaths
+from imcodex.observability.raw_protocol import RawProtocolWriter
 from imcodex.observability.runtime import ObservabilityRuntime
 
 
@@ -188,6 +189,39 @@ def test_event_writer_flushes_events_from_background_writer(tmp_path: Path) -> N
 
     archived = json.loads(paths.events_path.read_text(encoding="utf-8").strip())
     assert archived["event"] == "bridge.started"
+    writer.close()
+
+
+def test_raw_protocol_writer_snapshots_payload_before_background_write(tmp_path: Path) -> None:
+    paths = ObservabilityPaths.build(tmp_path, "instance-1")
+    paths.instance_dir.mkdir(parents=True)
+    paths.current_dir.mkdir(parents=True)
+    writer_started = Event()
+    release_writer = Event()
+
+    class SlowRawProtocolWriter(RawProtocolWriter):
+        def _write_payload(self, payload: str) -> None:
+            writer_started.set()
+            release_writer.wait(timeout=1)
+            super()._write_payload(payload)
+
+    writer = SlowRawProtocolWriter(paths=paths, context=_context(), clock=_clock)
+    payload = {"method": "thread/resume", "result": {"thread": {"turns": ["raw-turn"]}}}
+
+    writer.emit(
+        stage="received",
+        connection_mode="spawned-stdio",
+        connection_epoch=1,
+        payload=payload,
+    )
+    assert writer_started.wait(timeout=1)
+    payload["result"]["thread"]["turns"] = ["mutated-turn"]
+
+    release_writer.set()
+    writer.flush()
+
+    archived = json.loads(paths.raw_protocol_path.read_text(encoding="utf-8").strip())
+    assert archived["payload"]["result"]["thread"]["turns"] == ["raw-turn"]
     writer.close()
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -123,6 +123,7 @@ def test_build_runtime_constructs_observability_runtime(tmp_path: Path) -> None:
         http_port=8000,
         outbound_url=None,
         service_name="imcodex",
+        raw_protocol_log_enabled=False,
         qq_enabled=False,
         qq_app_id="",
         qq_client_secret="",
@@ -154,6 +155,7 @@ async def test_app_runtime_persists_launch_snapshot_for_restart_executor(tmp_pat
         http_port=8000,
         outbound_url=None,
         service_name="imcodex",
+        raw_protocol_log_enabled=False,
         qq_enabled=False,
         qq_app_id="",
         qq_client_secret="",
@@ -169,6 +171,7 @@ async def test_app_runtime_persists_launch_snapshot_for_restart_executor(tmp_pat
 
     assert launch["command"] == ["python", "-m", "imcodex"]
     assert launch["env"]["IMCODEX_DEBUG_API_ENABLED"] == "0"
+    assert launch["env"]["IMCODEX_RAW_PROTOCOL_LOG"] == "0"
     assert launch["env"]["IMCODEX_CORE_MODE"] == "dedicated-ws"
     assert launch["env"]["IMCODEX_CORE_URL"] == "ws://127.0.0.1:8765"
     assert launch["port"] == 8000


### PR DESCRIPTION
## Summary

- Classify native app-server `error` notifications so summarized telemetry keeps bounded error details instead of reducing them to unknown payload fingerprints.
- Add opt-in local raw protocol logging via `IMCODEX_RAW_PROTOCOL_LOG=1`.
- Write raw app-server transport records to `.imcodex-run/current/raw-protocol.jsonl` and the archived run directory, separate from shareable `events.jsonl` summaries.
- Snapshot raw protocol records before background writing so later in-memory payload normalization cannot alter the local raw log.
- Document the local-only raw log behavior in README, `.env.example`, and startup docs.

## Safety boundary

`events.jsonl` remains summary-oriented and avoids full unknown payload content. The raw protocol file is disabled by default and is intended for local diagnosis only because it can contain prompts, tool arguments, paths, connector data, or other native payload content.

## Validation

- `python -m pytest tests/test_observability.py -q` -> 8 passed
- `python -m pytest -q` -> 187 passed
- `agentkit check`
