### PR TITLE
[codex] Add native fast and reasoning controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Native Codex remains the source of truth for:
 - turn lifecycle
 - request identity
 - model continuity
+- reasoning effort
+- Fast mode service tier
 - permission and sandbox behavior
 
 Persisted bridge state is intentionally small:

--- a/docs/product-behavior-spec.md
+++ b/docs/product-behavior-spec.md
@@ -108,9 +108,11 @@ It should prominently include:
 - `/status`
 - `/stop`
 - `/model [model-id]`
+- `/think [effort]`
+- `/fast [on|off|status]`
 - `/permission [mode]`
 
-It should include short examples for `/model` and `/permission`.
+It should include short examples for `/model`, `/think`, and `/permission`.
 
 It does not need to expose contextual thread-browser commands or advanced commands such as:
 
@@ -207,6 +209,8 @@ It should show:
 - current thread
 - current state such as idle or working
 - current model
+- current reasoning effort
+- current Fast mode state
 - current permission mode
 - current bridge visibility profile
 - pending approval count when approvals are enabled in the product
@@ -234,6 +238,44 @@ Behavior:
 
 - model changes are written to native Codex config
 - the bridge does not invent a second long-term model authority
+
+### `/think`
+
+`/think` without arguments shows the current native reasoning effort and supported command choices.
+
+`/think <effort>` sets the native default reasoning effort.
+
+`/think default` clears the native reasoning-effort override.
+
+Supported product choices:
+
+- `minimal`
+- `low`
+- `medium`
+- `high`
+- `xhigh`
+- `default`
+
+Behavior:
+
+- reasoning-effort changes are written to native Codex config
+- the bridge does not maintain a second reasoning-effort truth
+- model-specific support and clamping remain native Codex behavior
+
+### `/fast`
+
+`/fast` or `/fast status` shows the current native Fast mode state.
+
+`/fast on` enables native Codex Fast mode.
+
+`/fast off` disables native Codex Fast mode.
+
+Behavior:
+
+- Fast mode changes are written to native Codex config
+- enabling Fast mode writes `service_tier = "fast"` and `features.fast_mode = true`
+- disabling Fast mode writes `service_tier = "standard"` and `features.fast_mode = false`
+- the bridge does not maintain a second speed-mode truth
 
 ### `/permission`
 

--- a/src/imcodex/bridge/commands.py
+++ b/src/imcodex/bridge/commands.py
@@ -23,6 +23,7 @@ _PERMISSION_PRESETS = {
         {"key_path": "sandbox_mode", "value": "danger-full-access", "merge_strategy": "replace"},
     ],
 }
+_REASONING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
 
 
 @dataclass(slots=True)
@@ -298,6 +299,64 @@ class CommandRouter:
         del channel_id, conversation_id, command
         return CommandResponse(action="models.list", text="")
 
+    def _handle_think(self, channel_id: str, conversation_id: str, command: ParsedCommand) -> CommandResponse:
+        del channel_id, conversation_id
+        if not command.args:
+            return CommandResponse(action="settings.reasoning.read", text="")
+        if len(command.args) != 1:
+            return CommandResponse(
+                action="settings.reasoning.invalid",
+                text="Usage: /think [minimal|low|medium|high|xhigh|default]",
+            )
+        effort = command.args[0].lower()
+        if effort == "default":
+            return CommandResponse(
+                action="settings.reasoning.write",
+                text="Native reasoning effort cleared.",
+                payload={"effort": None},
+            )
+        if effort not in _REASONING_EFFORTS:
+            return CommandResponse(
+                action="settings.reasoning.invalid",
+                text="Usage: /think [minimal|low|medium|high|xhigh|default]",
+            )
+        return CommandResponse(
+            action="settings.reasoning.write",
+            text=f"Native reasoning effort set to {effort}.",
+            payload={"effort": effort},
+        )
+
+    def _handle_fast(self, channel_id: str, conversation_id: str, command: ParsedCommand) -> CommandResponse:
+        del channel_id, conversation_id
+        if not command.args or command.args[0].lower() == "status":
+            if len(command.args) > 1:
+                return CommandResponse(action="settings.fast.invalid", text="Usage: /fast [on|off|status]")
+            return CommandResponse(action="settings.fast.read", text="")
+        if len(command.args) != 1:
+            return CommandResponse(action="settings.fast.invalid", text="Usage: /fast [on|off|status]")
+        mode = command.args[0].lower()
+        if mode == "on":
+            edits = [
+                {"key_path": "service_tier", "value": "fast", "merge_strategy": "replace"},
+                {"key_path": "features.fast_mode", "value": True, "merge_strategy": "replace"},
+            ]
+            return CommandResponse(
+                action="settings.fast.write",
+                text="Fast mode enabled.",
+                payload={"mode": "on", "edits": edits},
+            )
+        if mode == "off":
+            edits = [
+                {"key_path": "service_tier", "value": "standard", "merge_strategy": "replace"},
+                {"key_path": "features.fast_mode", "value": False, "merge_strategy": "replace"},
+            ]
+            return CommandResponse(
+                action="settings.fast.write",
+                text="Fast mode disabled.",
+                payload={"mode": "off", "edits": edits},
+            )
+        return CommandResponse(action="settings.fast.invalid", text="Usage: /fast [on|off|status]")
+
     def _handle_permission(self, channel_id: str, conversation_id: str, command: ParsedCommand) -> CommandResponse:
         del channel_id, conversation_id
         if not command.args:
@@ -485,6 +544,13 @@ class CommandRouter:
                     "/model [model-id]",
                     "Leave it empty to browse models, or switch directly.",
                     "Examples: /model gpt-5.4, /model gpt-5.3-codex",
+                    "",
+                    "/think [effort]",
+                    "Set native reasoning effort.",
+                    "Examples: /think low, /think xhigh, /think default",
+                    "",
+                    "/fast [on|off|status]",
+                    "Toggle native Codex Fast mode.",
                     "",
                     "/permission [mode]",
                     "Leave it empty to browse permission modes, or switch directly.",

--- a/src/imcodex/bridge/core.py
+++ b/src/imcodex/bridge/core.py
@@ -8,6 +8,16 @@ from ..models import InboundMessage, OutboundMessage
 from ..observability.message_trace import ensure_trace_id, text_preview, text_sha256
 from ..observability.runtime import emit_event
 from .server_requests import NativeRequestPolicy
+from .settings import (
+    current_model_label,
+    current_reasoning_label,
+    fast_mode_label,
+    permission_mode_label,
+    render_fast_mode,
+    render_models,
+    render_permission_modes,
+    render_reasoning_effort,
+)
 
 
 _SYSTEM_MESSAGE_TYPES = frozenset({"accepted", "status", "error"})
@@ -149,10 +159,16 @@ class BridgeService:
             return [self._message(message, "command_result", text)]
         if response.action == "models.list":
             result = await self.backend.list_models()
-            return [self._message(message, "command_result", self._render_models(result))]
+            return [self._message(message, "command_result", render_models(result))]
         if response.action == "settings.permission.read":
             result = await self.backend.read_config(message.channel_id, message.conversation_id)
-            return [self._message(message, "command_result", self._render_permission_modes(result))]
+            return [self._message(message, "command_result", render_permission_modes(result))]
+        if response.action == "settings.reasoning.read":
+            result = await self.backend.read_config(message.channel_id, message.conversation_id)
+            return [self._message(message, "command_result", render_reasoning_effort(result))]
+        if response.action == "settings.fast.read":
+            result = await self.backend.read_config(message.channel_id, message.conversation_id)
+            return [self._message(message, "command_result", render_fast_mode(result))]
         if response.action == "config.read":
             result = await self.backend.read_config(message.channel_id, message.conversation_id)
             key_path = None if response.payload is None else response.payload.get("key_path")
@@ -173,6 +189,25 @@ class BridgeService:
             return [self._message(message, "status", response.text)]
         if response.action == "settings.model":
             await self.backend.set_default_model(None if response.payload is None else response.payload.get("model"))
+            return [self._message(message, "status", response.text)]
+        if response.action == "settings.reasoning.write":
+            payload = response.payload or {}
+            await self.backend.write_config_value(
+                key_path="model_reasoning_effort",
+                value=payload.get("effort"),
+            )
+            return [self._message(message, "status", response.text)]
+        if response.action == "settings.fast.write":
+            payload = response.payload or {}
+            edits = [
+                {
+                    "keyPath": edit["key_path"],
+                    "value": edit["value"],
+                    "mergeStrategy": edit["merge_strategy"],
+                }
+                for edit in list(payload.get("edits") or [])
+            ]
+            await self.backend.batch_write_config(edits=edits, reload_user_config=False)
             return [self._message(message, "status", response.text)]
         if response.action == "settings.permission.write":
             payload = response.payload or {}
@@ -409,8 +444,10 @@ class BridgeService:
                 f"CWD: {cwd}",
                 f"Thread: {thread_label}",
                 f"State: {state}",
-                f"Model: {self._current_model_label(current_config)}",
-                f"Permissions: {self._permission_mode_label(current_config)}",
+                f"Model: {current_model_label(current_config)}",
+                f"Reasoning: {current_reasoning_label(current_config)}",
+                f"Fast mode: {fast_mode_label(current_config)}",
+                f"Permissions: {permission_mode_label(current_config)}",
                 f"Bridge visibility: {self._bridge_visibility_label(binding)}",
                 f"Pending approvals: {len(self.store.list_pending_requests(message.channel_id, message.conversation_id, kind='approval'))}",
             ]
@@ -461,6 +498,8 @@ class BridgeService:
             "settings.view",
             "settings.visibility",
             "settings.model",
+            "settings.reasoning.write",
+            "settings.fast.write",
             "settings.permission.write",
             "config.write",
             "config.batch",
@@ -477,36 +516,6 @@ class BridgeService:
         if action in {"thread.read.none", "turn.stop.none"}:
             return "command_result"
         return "command_result"
-
-    def _render_models(self, payload: dict) -> str:
-        items = payload.get("data")
-        if not isinstance(items, list) or not items:
-            return "Models\n\nCurrent: Unknown"
-        current = next((item for item in items if isinstance(item, dict) and item.get("isDefault")), None)
-        current_label = self._model_label(current) if isinstance(current, dict) else "Unknown"
-        lines = ["Models", "", f"Current: {current_label}", "", "Available:"]
-        for item in items:
-            if not isinstance(item, dict):
-                continue
-            lines.append(f"- {self._model_label(item)}")
-        lines.append("")
-        lines.append("Use /model <model-id> to switch directly.")
-        return "\n".join(lines)
-
-    def _render_permission_modes(self, payload: dict) -> str:
-        config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
-        current = self._permission_mode_label(config)
-        return "\n".join(
-            [
-                "Permission Modes",
-                "",
-                f"Current: {current}",
-                "",
-                "- /permission default",
-                "- /permission read-only",
-                "- /permission full-access",
-            ]
-        )
 
     def _render_config(self, payload: dict, key_path: object | None) -> str:
         config = payload.get("config")
@@ -641,31 +650,6 @@ class BridgeService:
                 "Use /cwd <path> to point me at an existing folder.",
             ]
         )
-
-    def _model_label(self, item: dict) -> str:
-        display = str(item.get("displayName") or item.get("model") or item.get("id") or "unknown")
-        model_id = str(item.get("model") or item.get("id") or display)
-        if display == model_id:
-            return display
-        return f"{display} ({model_id})"
-
-    def _current_model_label(self, config: dict) -> str:
-        model = config.get("model")
-        if not model:
-            return "Default"
-        return str(model)
-
-    def _permission_mode_label(self, config: dict) -> str:
-        approval = str(config.get("approval_policy") or "")
-        sandbox = str(config.get("sandbox_mode") or "")
-        if approval == "on-request" and sandbox == "workspace-write":
-            return "Default"
-        if approval == "on-request" and sandbox == "read-only":
-            return "Read Only"
-        if approval == "never" and sandbox == "danger-full-access":
-            return "Full Access"
-        details = ", ".join(part for part in (approval, sandbox) if part)
-        return f"Custom ({details})" if details else "Custom"
 
     def _bridge_visibility_label(self, binding) -> str:
         return binding.visibility_profile.replace("-", " ").title()

--- a/src/imcodex/bridge/settings.py
+++ b/src/imcodex/bridge/settings.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+
+def render_models(payload: dict) -> str:
+    items = payload.get("data")
+    if not isinstance(items, list) or not items:
+        return "Models\n\nCurrent: Unknown"
+    current = next((item for item in items if isinstance(item, dict) and item.get("isDefault")), None)
+    current_label = model_label(current) if isinstance(current, dict) else "Unknown"
+    lines = ["Models", "", f"Current: {current_label}", "", "Available:"]
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        lines.append(f"- {model_label(item)}")
+    lines.append("")
+    lines.append("Use /model <model-id> to switch directly.")
+    return "\n".join(lines)
+
+
+def render_reasoning_effort(payload: dict) -> str:
+    config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+    current = current_reasoning_label(config)
+    return "\n".join(
+        [
+            "Reasoning Effort",
+            "",
+            f"Current: {current}",
+            "",
+            "- /think minimal",
+            "- /think low",
+            "- /think medium",
+            "- /think high",
+            "- /think xhigh",
+            "- /think default",
+        ]
+    )
+
+
+def render_fast_mode(payload: dict) -> str:
+    config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+    current = fast_mode_label(config)
+    return "\n".join(
+        [
+            "Fast Mode",
+            "",
+            f"Current: {current}",
+            "",
+            "- /fast on",
+            "- /fast off",
+            "- /fast status",
+        ]
+    )
+
+
+def render_permission_modes(payload: dict) -> str:
+    config = payload.get("config") if isinstance(payload.get("config"), dict) else {}
+    current = permission_mode_label(config)
+    return "\n".join(
+        [
+            "Permission Modes",
+            "",
+            f"Current: {current}",
+            "",
+            "- /permission default",
+            "- /permission read-only",
+            "- /permission full-access",
+        ]
+    )
+
+
+def model_label(item: dict) -> str:
+    display = str(item.get("displayName") or item.get("model") or item.get("id") or "unknown")
+    model_id = str(item.get("model") or item.get("id") or display)
+    if display == model_id:
+        return display
+    return f"{display} ({model_id})"
+
+
+def current_model_label(config: dict) -> str:
+    model = config.get("model")
+    if not model:
+        return "Default"
+    return str(model)
+
+
+def current_reasoning_label(config: dict) -> str:
+    effort = config.get("model_reasoning_effort")
+    if not effort:
+        return "Default"
+    return str(effort)
+
+
+def fast_mode_label(config: dict) -> str:
+    tier = str(config.get("service_tier") or "").strip().lower()
+    features = config.get("features") if isinstance(config.get("features"), dict) else {}
+    fast_enabled = features.get("fast_mode") if isinstance(features, dict) else None
+    if tier == "fast" and fast_enabled is True:
+        return "Fast"
+    if tier in {"", "standard"} and fast_enabled in {None, False}:
+        return "Standard"
+    details = []
+    if tier:
+        details.append(f"service_tier={tier}")
+    if fast_enabled is not None:
+        details.append(f"fast_mode={str(fast_enabled).lower()}")
+    return f"Custom ({', '.join(details)})" if details else "Standard"
+
+
+def permission_mode_label(config: dict) -> str:
+    approval = str(config.get("approval_policy") or "")
+    sandbox = str(config.get("sandbox_mode") or "")
+    if approval == "on-request" and sandbox == "workspace-write":
+        return "Default"
+    if approval == "on-request" and sandbox == "read-only":
+        return "Read Only"
+    if approval == "never" and sandbox == "danger-full-access":
+        return "Full Access"
+    details = ", ".join(part for part in (approval, sandbox) if part)
+    return f"Custom ({details})" if details else "Custom"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -105,6 +105,8 @@ def test_help_lists_compact_top_level_commands_with_examples() -> None:
     assert "/pick <n>" in response.text
     assert "/model [model-id]" in response.text
     assert "/model gpt-5.4" in response.text
+    assert "/think [effort]" in response.text
+    assert "/fast [on|off|status]" in response.text
     assert "/permission [mode]" in response.text
     assert "/permission full-access" in response.text
     assert "/thread attach" not in response.text
@@ -201,6 +203,51 @@ def test_permission_without_args_opens_browser() -> None:
     response = router.handle("qq", "conv-1", "/permission")
 
     assert response.action == "settings.permission.read"
+
+
+def test_think_with_effort_builds_native_reasoning_payload() -> None:
+    store = ConversationStore(clock=lambda: 1.0)
+    router = CommandRouter(store)
+
+    response = router.handle("qq", "conv-1", "/think xhigh")
+
+    assert response.action == "settings.reasoning.write"
+    assert response.payload == {"effort": "xhigh"}
+
+
+def test_think_default_clears_native_reasoning_payload() -> None:
+    store = ConversationStore(clock=lambda: 1.0)
+    router = CommandRouter(store)
+
+    response = router.handle("qq", "conv-1", "/think default")
+
+    assert response.action == "settings.reasoning.write"
+    assert response.payload == {"effort": None}
+
+
+def test_fast_on_builds_native_fast_mode_payload() -> None:
+    store = ConversationStore(clock=lambda: 1.0)
+    router = CommandRouter(store)
+
+    response = router.handle("qq", "conv-1", "/fast on")
+
+    assert response.action == "settings.fast.write"
+    assert response.payload == {
+        "mode": "on",
+        "edits": [
+            {"key_path": "service_tier", "value": "fast", "merge_strategy": "replace"},
+            {"key_path": "features.fast_mode", "value": True, "merge_strategy": "replace"},
+        ],
+    }
+
+
+def test_fast_status_reads_native_config() -> None:
+    store = ConversationStore(clock=lambda: 1.0)
+    router = CommandRouter(store)
+
+    response = router.handle("qq", "conv-1", "/fast status")
+
+    assert response.action == "settings.fast.read"
 
 
 def test_permission_with_mode_builds_native_permission_payload() -> None:

--- a/tests/test_service_e2e.py
+++ b/tests/test_service_e2e.py
@@ -1332,6 +1332,139 @@ async def test_model_default_clears_native_default_model_config() -> None:
 
 
 @pytest.mark.asyncio
+async def test_think_command_writes_native_reasoning_effort_config() -> None:
+    process = ScriptedProcess(
+        {
+            "initialize": [{"id": 1, "result": {"ok": True}}],
+            "config/value/write": [
+                {
+                    "id": 2,
+                    "result": {
+                        "status": "updated",
+                        "version": "v3",
+                        "filePath": r"D:\Users\me\.codex\config.toml",
+                        "overriddenMetadata": None,
+                    },
+                }
+            ],
+        }
+    )
+    store = ConversationStore(clock=lambda: 1.0)
+    sink = CapturingSink()
+    client, service = _build_service(store, process, sink)
+
+    messages = await service.handle_inbound(
+        InboundMessage(
+            channel_id="qq",
+            conversation_id="conv-1",
+            user_id="u1",
+            message_id="m1",
+            text="/think high",
+        )
+    )
+
+    assert messages[0].message_type == "status"
+    payloads = [payload["params"] for payload in process.inputs if payload.get("method") == "config/value/write"]
+    assert payloads == [{"keyPath": "model_reasoning_effort", "value": "high", "mergeStrategy": "replace"}]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_fast_command_writes_native_fast_mode_config() -> None:
+    process = ScriptedProcess(
+        {
+            "initialize": [{"id": 1, "result": {"ok": True}}],
+            "config/batchWrite": [{"id": 2, "result": {"status": "updated"}}],
+        }
+    )
+    store = ConversationStore(clock=lambda: 1.0)
+    sink = CapturingSink()
+    client, service = _build_service(store, process, sink)
+
+    messages = await service.handle_inbound(
+        InboundMessage(
+            channel_id="qq",
+            conversation_id="conv-1",
+            user_id="u1",
+            message_id="m1",
+            text="/fast on",
+        )
+    )
+
+    assert messages[0].message_type == "status"
+    payloads = [payload["params"] for payload in process.inputs if payload.get("method") == "config/batchWrite"]
+    assert payloads == [
+        {
+            "edits": [
+                {"keyPath": "service_tier", "value": "fast", "mergeStrategy": "replace"},
+                {"keyPath": "features.fast_mode", "value": True, "mergeStrategy": "replace"},
+            ],
+            "reloadUserConfig": False,
+        }
+    ]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_think_and_fast_without_args_read_native_config() -> None:
+    process = ScriptedProcess(
+        {
+            "initialize": [{"id": 1, "result": {"ok": True}}],
+            "config/read": [
+                {
+                    "id": 2,
+                    "result": {
+                        "config": {
+                            "model_reasoning_effort": "high",
+                            "service_tier": "fast",
+                            "features": {"fast_mode": True},
+                        }
+                    },
+                },
+                {
+                    "id": 3,
+                    "result": {
+                        "config": {
+                            "model_reasoning_effort": "high",
+                            "service_tier": "fast",
+                            "features": {"fast_mode": True},
+                        }
+                    },
+                },
+            ],
+        }
+    )
+    store = ConversationStore(clock=lambda: 1.0)
+    sink = CapturingSink()
+    client, service = _build_service(store, process, sink)
+
+    think_messages = await service.handle_inbound(
+        InboundMessage(
+            channel_id="qq",
+            conversation_id="conv-1",
+            user_id="u1",
+            message_id="m1",
+            text="/think",
+        )
+    )
+    fast_messages = await service.handle_inbound(
+        InboundMessage(
+            channel_id="qq",
+            conversation_id="conv-1",
+            user_id="u1",
+            message_id="m2",
+            text="/fast",
+        )
+    )
+
+    assert "Reasoning Effort" in think_messages[0].text
+    assert "Current: high" in think_messages[0].text
+    assert "Fast Mode" in fast_messages[0].text
+    assert "Current: Fast" in fast_messages[0].text
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_config_write_command_sends_native_json_value_write() -> None:
     process = ScriptedProcess(
         {
@@ -1494,6 +1627,9 @@ async def test_status_and_thread_read_render_transport_mode_and_thread_source() 
                     "result": {
                         "config": {
                             "model": "gpt-5.4",
+                            "model_reasoning_effort": "high",
+                            "service_tier": "fast",
+                            "features": {"fast_mode": True},
                             "approval_policy": "on-request",
                             "sandbox_mode": "workspace-write",
                         }
@@ -1558,6 +1694,8 @@ async def test_status_and_thread_read_render_transport_mode_and_thread_source() 
     assert "Status" in status_messages[0].text
     assert "CWD: D:\\work\\alpha" in status_messages[0].text
     assert "Model: gpt-5.4" in status_messages[0].text
+    assert "Reasoning: high" in status_messages[0].text
+    assert "Fast mode: Fast" in status_messages[0].text
     assert "Permissions: Default" in status_messages[0].text
     assert "Bridge visibility: Standard" in status_messages[0].text
     assert "Source: appServer" in thread_messages[0].text


### PR DESCRIPTION
## Summary
- Add `/think` to read, set, and clear native `model_reasoning_effort`.
- Add `/fast` to read and toggle native Fast mode via `service_tier` and `features.fast_mode`.
- Show reasoning effort and Fast mode in `/status`, with settings rendering extracted from bridge core.
- Document the new product behavior and add command/e2e coverage.

## Validation
- `uv run pytest tests/test_commands.py tests/test_service_e2e.py tests/test_architecture.py -q`
- `uv run pytest -q`
- `agentkit check`

## Notes
- The bridge only writes native Codex config and does not persist bridge-owned model, reasoning, or speed state.
- AgentKit review was skipped because clean-context subagent review is not available under this session's delegation policy; full local tests and AgentKit checks passed.