### PR TITLE
[codex] Render credits in local time

### DIFF
--- a/agentkit.yml
+++ b/agentkit.yml
@@ -56,6 +56,7 @@ components:
       - src/imcodex/store.py
       - src/imcodex/models.py
       - tests/test_commands.py
+      - tests/test_settings.py
       - tests/test_projection*.py
       - tests/test_service_e2e.py
     docs:

--- a/docs/product-behavior-spec.md
+++ b/docs/product-behavior-spec.md
@@ -226,6 +226,8 @@ Behavior:
 
 - credits and rate-limit state are read from Codex with `account/rateLimits/read`
 - the bridge does not persist credits or infer a local quota
+- rate-limit window percentages are shown as remaining capacity rather than consumed usage
+- rate-limit reset timestamps are rendered as local date/time using the user's or runtime environment's detected timezone, with UTC as the fallback if local timezone detection is unavailable
 - if Codex cannot provide the data, the user gets a friendly status response rather than protocol noise
 
 ### `/stop`

--- a/src/imcodex/bridge/settings.py
+++ b/src/imcodex/bridge/settings.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
 
 def render_models(payload: dict) -> str:
     items = payload.get("data")
@@ -166,13 +170,56 @@ def _rate_limit_snapshot(payload: dict) -> dict | None:
     return rate_limits if isinstance(rate_limits, dict) else None
 
 
-def _rate_limit_window_label(label: str, window: dict) -> str:
-    used = window.get("usedPercent")
-    parts = [f"{label}: {used}%" if used is not None else f"{label}: unknown"]
+def _rate_limit_window_label(label: str, window: dict, *, tz=None) -> str:
+    remaining = _remaining_percent(window.get("usedPercent"))
+    parts = [f"{label}: {remaining} remaining" if remaining is not None else f"{label}: unknown"]
     duration = window.get("windowDurationMins")
     if duration is not None:
         parts.append(f"window {duration} min")
     resets_at = window.get("resetsAt")
     if resets_at is not None:
-        parts.append(f"resets at {resets_at}")
+        parts.append(f"resets at {_format_reset_time(resets_at, tz=tz)}")
     return ", ".join(parts)
+
+
+def _remaining_percent(used_percent: Any) -> str | None:
+    if used_percent is None:
+        return None
+    try:
+        used = float(str(used_percent).strip().rstrip("%"))
+    except (TypeError, ValueError):
+        return None
+    remaining = max(0.0, min(100.0, 100.0 - used))
+    if remaining.is_integer():
+        return f"{int(remaining)}%"
+    return f"{remaining:.1f}".rstrip("0").rstrip(".") + "%"
+
+
+def _format_reset_time(value: Any, *, tz=None) -> str:
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    target_tz = tz
+    if target_tz is None:
+        target_tz = datetime.now().astimezone().tzinfo or timezone.utc
+    reset = datetime.fromtimestamp(timestamp, timezone.utc).astimezone(target_tz)
+    offset = _utc_offset_label(reset)
+    zone_name = reset.tzname()
+    if zone_name and zone_name != offset:
+        zone_label = f"{zone_name} ({offset})"
+    else:
+        zone_label = offset
+    return f"{reset:%Y-%m-%d %H:%M:%S} {zone_label}"
+
+
+def _utc_offset_label(value: datetime) -> str:
+    offset = value.utcoffset()
+    if offset is None:
+        return "UTC"
+    total_seconds = int(offset.total_seconds())
+    sign = "+" if total_seconds >= 0 else "-"
+    total_seconds = abs(total_seconds)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes = remainder // 60
+    return f"UTC{sign}{hours:02d}:{minutes:02d}"

--- a/tests/test_service_e2e.py
+++ b/tests/test_service_e2e.py
@@ -1455,6 +1455,8 @@ async def test_credits_command_reads_account_rate_limits() -> None:
     assert "Credits" in messages[0].text
     assert "Current: Available" in messages[0].text
     assert "Balance: 123" in messages[0].text
+    assert "Primary: 75% remaining" in messages[0].text
+    assert "resets at 1730947200" not in messages[0].text
     payloads = [payload for payload in process.inputs if payload.get("method") == "account/rateLimits/read"]
     assert payloads == [{"id": 2, "method": "account/rateLimits/read"}]
     await client.close()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from datetime import timezone
+
+from imcodex.bridge.settings import _rate_limit_window_label
+from imcodex.bridge.settings import render_credits
+
+
+def test_rate_limit_window_label_shows_remaining_percent_and_local_reset_time() -> None:
+    china_time = timezone(timedelta(hours=8), "CST")
+
+    label = _rate_limit_window_label(
+        "Primary",
+        {
+            "usedPercent": 2,
+            "windowDurationMins": 300,
+            "resetsAt": 1778436562,
+        },
+        tz=china_time,
+    )
+
+    assert label == "Primary: 98% remaining, window 300 min, resets at 2026-05-11 02:09:22 CST (UTC+08:00)"
+
+
+def test_rate_limit_window_label_formats_fractional_remaining_percent() -> None:
+    china_time = timezone(timedelta(hours=8), "CST")
+
+    label = _rate_limit_window_label(
+        "Secondary",
+        {
+            "usedPercent": "41.5",
+            "windowDurationMins": 10080,
+            "resetsAt": 1778732836,
+        },
+        tz=china_time,
+    )
+
+    assert label == "Secondary: 58.5% remaining, window 10080 min, resets at 2026-05-14 12:27:16 CST (UTC+08:00)"
+
+
+def test_render_credits_uses_remaining_language() -> None:
+    text = render_credits(
+        {
+            "rateLimits": {
+                "limitId": "codex",
+                "credits": {"hasCredits": False, "balance": 0},
+                "primary": {"usedPercent": 2},
+                "secondary": {"usedPercent": 41},
+            }
+        }
+    )
+
+    assert "Current: Depleted" in text
+    assert "Primary: 98% remaining" in text
+    assert "Secondary: 59% remaining" in text
+    assert "Primary: 2%" not in text


### PR DESCRIPTION
## Summary
- Render `/credits` reset timestamps as local date/time using the runtime-detected timezone instead of exposing raw Unix timestamps.
- Show rate-limit window percentages as remaining capacity instead of consumed usage.
- Document the behavior in the product spec and add focused formatting/e2e coverage.
- Map `tests/test_settings.py` into AgentKit bridge component ownership.

## Validation
- `python -m pytest tests/test_settings.py tests/test_service_e2e.py::test_credits_command_reads_account_rate_limits tests/test_commands.py::test_credits_command_reads_account_rate_limits -q` -> 5 passed
- `python -m pytest -q` -> 197 passed
- `agentkit check`

Fixes #9