### PR TITLE
[codex] Gracefully stop exited appserver process

### DIFF
--- a/src/imcodex/appserver/supervisor.py
+++ b/src/imcodex/appserver/supervisor.py
@@ -78,16 +78,26 @@ class AppServerSupervisor:
         if self._process is None:
             self._connection_mode = "disconnected"
             return
-        terminate = getattr(self._process, "terminate", None)
-        if callable(terminate):
-            terminate()
-        wait = getattr(self._process, "wait", None)
-        if callable(wait):
-            result = wait()
-            if inspect.isawaitable(result):
-                await result
-        self._process = None
-        self._connection_mode = "disconnected"
+        process = self._process
+        try:
+            if getattr(process, "returncode", None) is None:
+                terminate = getattr(process, "terminate", None)
+                if callable(terminate):
+                    try:
+                        terminate()
+                    except ProcessLookupError:
+                        pass
+            wait = getattr(process, "wait", None)
+            if callable(wait):
+                try:
+                    result = wait()
+                    if inspect.isawaitable(result):
+                        await result
+                except ProcessLookupError:
+                    pass
+        finally:
+            self._process = None
+            self._connection_mode = "disconnected"
 
     async def _default_spawn(self, *command: str) -> Any:
         resolved = self._resolve_command_for_spawn(command)

--- a/tests/test_appserver_stdio.py
+++ b/tests/test_appserver_stdio.py
@@ -542,6 +542,36 @@ async def test_default_spawn_uses_larger_stream_limit(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_supervisor_stop_tolerates_already_exited_process() -> None:
+    class AlreadyExitedProcess:
+        def __init__(self) -> None:
+            self.returncode = None
+            self.terminate_called = False
+            self.wait_called = False
+
+        def terminate(self) -> None:
+            self.terminate_called = True
+            raise ProcessLookupError()
+
+        async def wait(self) -> int:
+            self.wait_called = True
+            self.returncode = 0
+            return 0
+
+    process = AlreadyExitedProcess()
+    supervisor = AppServerSupervisor()
+    supervisor._process = process
+    supervisor._connection_mode = "spawned-stdio"
+
+    await supervisor.stop()
+
+    assert process.terminate_called is True
+    assert process.wait_called is True
+    assert supervisor.process is None
+    assert supervisor.connection_mode == "disconnected"
+
+
+@pytest.mark.asyncio
 async def test_client_uses_explicit_websocket_app_server_before_spawning() -> None:
     websocket = ScriptedWebSocket(
         {


### PR DESCRIPTION
## Summary
- Treat `ProcessLookupError` during appserver subprocess shutdown as an already-exited process instead of surfacing it through Starlette lifespan shutdown.
- Skip terminate when the supervisor can already see a process return code.
- Always clear supervisor process state and mark the connection disconnected during stop cleanup.
- Add regression coverage for the Ctrl+C/already-exited subprocess path.

## Validation
- `python -m pytest tests/test_appserver_stdio.py::test_supervisor_stop_tolerates_already_exited_process -q` -> 1 passed
- `python -m pytest tests/test_appserver_stdio.py -q` -> 22 passed
- `python -m pytest -q` -> 198 passed
- `agentkit check`